### PR TITLE
Revert use of yew-router

### DIFF
--- a/nextspeaker-web/Cargo.lock
+++ b/nextspeaker-web/Cargo.lock
@@ -535,7 +535,6 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d5564e570a38b43d78bdc063374a0c3098c4f0d64005b12f9bbe87e869b6d7"
 dependencies = [
- "futures-channel",
  "gloo-events",
  "js-sys",
  "wasm-bindgen",
@@ -625,8 +624,6 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
 dependencies = [
- "futures-channel",
- "futures-core",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -864,7 +861,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "yew",
- "yew-router",
  "yewdux",
 ]
 
@@ -1085,12 +1081,6 @@ dependencies = [
  "num-traits",
  "rand",
 ]
-
-[[package]]
-name = "route-recognizer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rustc-demangle"
@@ -1652,35 +1642,6 @@ dependencies = [
  "once_cell",
  "prettyplease",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "yew-router"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426ee0486d2572a6c5e39fbdbc48b58d59bb555f3326f54631025266cf04146e"
-dependencies = [
- "gloo",
- "js-sys",
- "route-recognizer",
- "serde",
- "serde_urlencoded",
- "tracing",
- "wasm-bindgen",
- "web-sys",
- "yew",
- "yew-router-macro",
-]
-
-[[package]]
-name = "yew-router-macro"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b249cdb39e0cddaf0644dedc781854524374664793479fdc01e6a65d6e6ae3"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/nextspeaker-web/Cargo.toml
+++ b/nextspeaker-web/Cargo.toml
@@ -19,5 +19,4 @@ stylist = { version = "0.12.1", features = ["yew_integration", "yew"] }
 wasm-bindgen = "0.2.87"
 web-sys = { version = "0.3.64", features = ["HtmlTextAreaElement", "HtmlInputElement"] }
 yew = { version = "0.20.0", features = ["csr"] }
-yew-router = "0.17"
 yewdux = "0.9.3"

--- a/nextspeaker-web/src/components.rs
+++ b/nextspeaker-web/src/components.rs
@@ -5,28 +5,24 @@ use stylist::yew::styled_component;
 use wasm_bindgen::JsValue;
 use web_sys::{HtmlInputElement, HtmlTextAreaElement};
 use yew::prelude::*;
-use yew_router::prelude::*;
 use yewdux::prelude::*;
 
-use crate::simulate;
 use crate::state;
-use crate::Mode;
 use crate::N_SIM;
 
 #[derive(Properties, Debug, PartialEq)]
 pub struct DismissablePanelProps {
+    pub dismiss: Callback<MouseEvent>,
     #[prop_or_default]
     pub children: Html,
 }
 
 #[styled_component]
 pub fn DismissablePanel(props: &DismissablePanelProps) -> Html {
-    let navigator = use_navigator().unwrap();
-    let dismiss = Callback::from(move |_| navigator.push(&Mode::MainView));
     html! {
         <div class={css!("display: flex; background-color: lightgray; flex-direction: column;")}>
             <div class={css!("display: flex; flex-flow: row-reverse;")}>
-                <DismissButton onclick={dismiss} />
+                <DismissButton onclick={props.dismiss.clone()} />
                 <div class={css!("flex: 1;")} />
             </div>
             {props.children.clone()}
@@ -259,37 +255,15 @@ pub fn DismissButton(props: &DismissButtonProps) -> Html {
 }
 
 #[derive(Properties, PartialEq)]
-pub struct ModeSelectProps {}
+pub struct ModeSelectProps {
+    pub buttons: Html,
+}
 
 #[styled_component]
-pub fn ModeSelect(_props: &ModeSelectProps) -> Html {
-    let navigator = use_navigator().unwrap();
-    let candidates = Callback::from(move |_| navigator.push(&Mode::CandidatesView));
-    let navigator = use_navigator().unwrap();
-    let history = Callback::from(move |_| navigator.push(&Mode::HistoryView));
-    let navigator = use_navigator().unwrap();
-    let simulation = Callback::from(move |_| {
-        yew::platform::spawn_local(async {
-            log!(JsValue::from("run sim thing"));
-            let candidates = Dispatch::<state::Candidates>::new().get();
-            let history = Dispatch::<state::History>::new().get();
-            let history_halflife = Dispatch::<state::HistoryHalflife>::new().get().into_f64();
-            let results = simulate::run(&candidates.value, &history.value, history_halflife);
-            Dispatch::<state::SimulationResults>::new()
-                .set(state::SimulationResults { value: results });
-        });
-        navigator.push(&Mode::SimulationView);
-    });
-    let mode_select_buttons = html! {
-        <div>
-            <button onclick={candidates}>{"candidates"}</button>
-            <button onclick={history}>{"history"}</button>
-            <button onclick={simulation}>{"simulate"}</button>
-        </div>
-    };
+pub fn ModeSelect(props: &ModeSelectProps) -> Html {
     html! {
         <div class={css!("width: 50%; padding: 3rem; margin: 1rem;")}>
-            { mode_select_buttons }
+            { props.buttons.clone() }
         </div>
     }
 }

--- a/nextspeaker-web/src/main.rs
+++ b/nextspeaker-web/src/main.rs
@@ -15,13 +15,13 @@ const N_SIM: u64 = 1000;
 
 #[derive(Clone, Debug, Eq, PartialEq, Routable)]
 pub enum Mode {
-    #[at("/candidates")]
+    #[at("/nextspeaker/candidates")]
     CandidatesView,
-    #[at("/history")]
+    #[at("/nextspeaker/history")]
     HistoryView,
-    #[at("/")]
+    #[at("/nextspeaker/")]
     MainView,
-    #[at("/simulation")]
+    #[at("/nextspeaker/simulation")]
     SimulationView,
 }
 

--- a/nextspeaker-web/src/state.rs
+++ b/nextspeaker-web/src/state.rs
@@ -1,6 +1,11 @@
 use serde::{Deserialize, Serialize};
 use yewdux::prelude::*;
 
+#[derive(Debug, Default, Clone, PartialEq, Eq, Store)]
+pub struct AppMode {
+    pub value: crate::Mode,
+}
+
 #[derive(Debug, Default, Clone, Deserialize, PartialEq, Eq, Serialize, Store)]
 #[store(storage = "local")]
 pub struct Candidates {


### PR DESCRIPTION
Use of yew-router remains in the git history as an example but is not appropriate for Github Pages.