### PR TITLE
Support Trimming Optional Initial Field in History

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "nextspeaker"
 version = "0.1.0"
 dependencies = [
@@ -206,6 +221,7 @@ dependencies = [
  "log",
  "rand",
  "rand_distr",
+ "regex",
  "simple_logger",
 ]
 
@@ -327,6 +343,35 @@ dependencies = [
  "num-traits",
  "rand",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ clap = { version = "4.0.9", features = ["derive"] }
 log = "0.4.19"
 rand = "0.8.5"
 rand_distr = "0.4.3"
+regex = "1.11.1"
 simple_logger = { version = "4.2.0", features = ["stderr"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,22 @@ pub const DEFAULT_HALFLIFE: f64 = 10.0;
 
 #[derive(Parser, Debug)]
 pub struct Args {
+    /// The list of participants, one per line
     pub participants: PathBuf,
+
+    /// The previous history of participation
     #[arg(long)]
     pub history: Option<PathBuf>,
+
+    /// Whether to trim an initial whitespace-delimited field from history
+    #[arg(long, action)]
+    pub history_trim: bool,
+
+    /// The time for participation to matter half as much
     #[arg(long, default_value_t = DEFAULT_HALFLIFE)]
     pub history_halflife: f64,
+
+    /// The number of simulations to run
     #[arg(long)]
     pub n_simulations: Option<usize>,
 }
@@ -292,6 +303,7 @@ mod test {
                 participants: PathBuf::from("dummy"),
                 history: Some(PathBuf::from("dummy-history")),
                 history_halflife: 10.0,
+                history_trim: false,
                 n_simulations: None,
             }
         }


### PR DESCRIPTION
I want to be able to have histories like this:

    20250126 Earnie
    20250127 Bert
    20250128 Big Bird

... so that the first whitespace-delimited field is metadata about the historical record of participation.